### PR TITLE
Fix vault_ca and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Based on [Kelsey Hightower](https://github.com/kelseyhightower/vault-on-google-k
 | vault_load_balancer_fqdn | FQDN entry that points to the Vault Load Balancer | string | `` | no |
 | vault_load_balancer_ip | Reserved IP address that will be used by Vault Kubernetes Service | string | `` | no |
 | vault_replica_count | The number of vault replicas to deploy | string | `3` | no |
+| vault_request_cpu | Kubernetes CPU Request for Vault pods | string | `500m` | no |
+| vault_request_memory | Kubernetes Memory Request for Vault pods | string | `1Gi` | no |
 | vault_tls_cert | The Base64 encoded TLS certificate for vault server. If none is supplied, a CA will be created and used to sign a generated certificate. | string | `` | no |
 | vault_tls_key | The Base64 encoded TLS key for vault server. If none is supplied, a private key will be generated. | string | `` | no |
 

--- a/kubernetes_vault_stateful_set.tf
+++ b/kubernetes_vault_stateful_set.tf
@@ -44,14 +44,23 @@ resource kubernetes_stateful_set vault {
         # }
         */
 
+        termination_grace_period_seconds = 10
+
         container {
           name              = "vault-init"
           image             = "${var.vault_init_image_repository}:${var.vault_init_image_tag}"
-          image_pull_policy = "IfNotPresent"
+          image_pull_policy = "Always"
+
+          resources {
+            requests {
+              cpu    = "100m"
+              memory = "64Mi"
+            }
+          }
 
           env {
             name  = "CHECK_INTERVAL"
-            value = "5"
+            value = "30"
           }
 
           env {
@@ -157,8 +166,8 @@ EOF
 
           resources {
             requests {
-              cpu    = "500m"
-              memory = "1Gi"
+              cpu    = "${var.vault_request_cpu}"
+              memory = "${var.vault_request_memory}"
             }
           }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,7 @@ output "address" {
   value = "${coalesce(var.vault_load_balancer_ip, join("", google_compute_address.vault.*.address))}"
 }
 
-data template_file env {
+data "template_file" "env" {
   template = <<EOF
   
 export VAULT_ADDR="https://$${addr}:8200"

--- a/tls.tf
+++ b/tls.tf
@@ -30,11 +30,11 @@ resource "tls_self_signed_cert" "vault_ca" {
   # }
 }
 
-resource local_file vault_ca {
+resource "local_file" "vault_ca" {
   count = "${local.create_tls_resources}"
 
   filename = "vault_ca.pem"
-  contents = "${tls_self_signed_cert.vault_ca.cert_pem}"
+  content  = "${tls_self_signed_cert.vault_ca.cert_pem}"
 }
 
 # Create the Vault server certificates

--- a/variables.tf
+++ b/variables.tf
@@ -95,3 +95,13 @@ variable vault_tls_key {
   description = "The Base64 encoded TLS key for vault server. If none is supplied, a private key will be generated."
   default     = ""
 }
+
+variable vault_request_cpu {
+  description = "Kubernetes CPU Request for Vault pods"
+  default = "500m"
+}
+
+variable vault_request_memory {
+  description = "Kubernetes Memory Request for Vault pods"
+  default = "1Gi"
+}


### PR DESCRIPTION
There was a typo in the `local_file.vault_ca` stanza.  I fixed that.

I also added some quoting and some updates lifted from the [sethvargo/vault-on-gke repo](https://github.com/sethvargo/vault-on-gke).    This adds a small CPU request for `vault-init`.

I needed a smaller `vault` CPU request for my test cluster so I exposed that as a Terraform variable.

Thanks for this and especially for the `terraform-provider-kubernetes` work -- we love using it.